### PR TITLE
Replace HTML with Markdown

### DIFF
--- a/src/templates/CONTRIBUTING.md
+++ b/src/templates/CONTRIBUTING.md
@@ -40,7 +40,7 @@ You can also reach us at hello@{{slug}}.opencollective.com.
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/{{org}}/{{repo}}/graphs/contributors"><img src="https://opencollective.com/{{slug}}/contributors.svg?width=890&button=false" /></a>
+[![Code Contributors](https://opencollective.com/{{slug}}/contributors.svg?width=890&button=false)](https://github.com/{{org}}/{{repo}}/graphs/contributors)
 
 ### Financial Contributors
 
@@ -48,21 +48,21 @@ Become a financial contributor and help us sustain our community. [[Contribute](
 
 #### Individuals
 
-<a href="https://opencollective.com/{{slug}}"><img src="https://opencollective.com/{{slug}}/individuals.svg?width=890"></a>
+[![Contributing Individuals](https://opencollective.com/{{slug}}/individuals.svg?width=890)](https://opencollective.com/{{slug}})
 
 #### Organizations
 
 Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/{{slug}}/contribute)]
 
-<a href="https://opencollective.com/{{slug}}/organization/0/website"><img src="https://opencollective.com/{{slug}}/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/1/website"><img src="https://opencollective.com/{{slug}}/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/2/website"><img src="https://opencollective.com/{{slug}}/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/3/website"><img src="https://opencollective.com/{{slug}}/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/4/website"><img src="https://opencollective.com/{{slug}}/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/5/website"><img src="https://opencollective.com/{{slug}}/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/6/website"><img src="https://opencollective.com/{{slug}}/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/7/website"><img src="https://opencollective.com/{{slug}}/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/8/website"><img src="https://opencollective.com/{{slug}}/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/9/website"><img src="https://opencollective.com/{{slug}}/organization/9/avatar.svg"></a>
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/0/avatar.svg)](https://opencollective.com/{{slug}}/organization/0/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/1/avatar.svg)](https://opencollective.com/{{slug}}/organization/1/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/2/avatar.svg)](https://opencollective.com/{{slug}}/organization/2/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/3/avatar.svg)](https://opencollective.com/{{slug}}/organization/3/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/4/avatar.svg)](https://opencollective.com/{{slug}}/organization/4/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/5/avatar.svg)](https://opencollective.com/{{slug}}/organization/5/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/6/avatar.svg)](https://opencollective.com/{{slug}}/organization/6/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/7/avatar.svg)](https://opencollective.com/{{slug}}/organization/7/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/8/avatar.svg)](https://opencollective.com/{{slug}}/organization/8/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/9/avatar.svg)](https://opencollective.com/{{slug}}/organization/9/website)
 
 <!-- This `CONTRIBUTING.md` is based on @nayafia's template https://github.com/nayafia/contributing-template -->

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -3,7 +3,7 @@
 ### Code Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/{{org}}/{{repo}}/graphs/contributors"><img src="https://opencollective.com/{{slug}}/contributors.svg?width=890&button=false" /></a>
+[![GitHub contributors](https://opencollective.com/{{slug}}/contributors.svg?width=890&button=false)](https://github.com/{{org}}/{{repo}}/graphs/contributors)
 
 ### Financial Contributors
 
@@ -11,19 +11,19 @@ Become a financial contributor and help us sustain our community. [[Contribute](
 
 #### Individuals
 
-<a href="https://opencollective.com/{{slug}}"><img src="https://opencollective.com/{{slug}}/individuals.svg?width=890"></a>
+[![Contributing Individuals](https://opencollective.com/{{slug}}/individuals.svg?width=890)](https://opencollective.com/{{slug}})
 
 #### Organizations
 
 Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/{{slug}}/contribute)]
 
-<a href="https://opencollective.com/{{slug}}/organization/0/website"><img src="https://opencollective.com/{{slug}}/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/1/website"><img src="https://opencollective.com/{{slug}}/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/2/website"><img src="https://opencollective.com/{{slug}}/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/3/website"><img src="https://opencollective.com/{{slug}}/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/4/website"><img src="https://opencollective.com/{{slug}}/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/5/website"><img src="https://opencollective.com/{{slug}}/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/6/website"><img src="https://opencollective.com/{{slug}}/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/7/website"><img src="https://opencollective.com/{{slug}}/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/8/website"><img src="https://opencollective.com/{{slug}}/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/{{slug}}/organization/9/website"><img src="https://opencollective.com/{{slug}}/organization/9/avatar.svg"></a>
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/0/avatar.svg)](https://opencollective.com/{{slug}}/organization/0/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/1/avatar.svg)](https://opencollective.com/{{slug}}/organization/1/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/2/avatar.svg)](https://opencollective.com/{{slug}}/organization/2/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/3/avatar.svg)](https://opencollective.com/{{slug}}/organization/3/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/4/avatar.svg)](https://opencollective.com/{{slug}}/organization/4/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/5/avatar.svg)](https://opencollective.com/{{slug}}/organization/5/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/6/avatar.svg)](https://opencollective.com/{{slug}}/organization/6/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/7/avatar.svg)](https://opencollective.com/{{slug}}/organization/7/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/8/avatar.svg)](https://opencollective.com/{{slug}}/organization/8/website)
+[![Contributing Organization](https://opencollective.com/{{slug}}/organization/9/avatar.svg)](https://opencollective.com/{{slug}}/organization/9/website)


### PR DESCRIPTION
In the files that are specifically markdown files (ending in `.md` file extension) this replaces the HTML with markdown. There's no critical reason for doing this, but some repositories (such as my own) run markdown files through tools like markdownlint that are unhappy with the use of HTML in markdown files.